### PR TITLE
Beginnings of a Unicode-everywhere policy - psycopg2

### DIFF
--- a/fore/database.py
+++ b/fore/database.py
@@ -7,6 +7,14 @@ from mutagen.mp3 import MP3
 _conn = psycopg2.connect(apikeys.db_connect_string)
 log = logging.getLogger(__name__)
 
+# Enable Unicode return values for all database queries
+# This would be the default in Python 3, but in Python 2, we
+# need to enable these two extensions.
+# http://initd.org/psycopg/docs/usage.html#unicode-handling
+import psycopg2.extensions
+psycopg2.extensions.register_type(psycopg2.extensions.UNICODE)
+psycopg2.extensions.register_type(psycopg2.extensions.UNICODEARRAY)
+
 class Track(object):
 	def __init__(self, id, filename, artist, title, length, status, 
 				submitter, submitteremail, submitted, lyrics, story):


### PR DESCRIPTION
Configure psycopg2 to return Unicode from all DB requests.
This may break stuff, and should be checked for consequences; but any issues
are just uncovering what was already there, not actually caused by this patch.
