### PR TITLE
Remove the remaining traces of relays.

### DIFF
--- a/fore/monitor.py
+++ b/fore/monitor.py
@@ -66,11 +66,11 @@ class MonitorSocket(tornadio2.conn.SocketConnection):
 	def on_message(self, message):
 		pass
 
-def monitordaemon(relays, get_stats, queues):
+def monitordaemon(clients, get_stats, queues):
 	while True:
 		time.sleep(config.monitor_update_time)
 		MonitorSocket.update({
-			"listeners": [dict(dict(g.request.headers).items() + [("remote_ip", g.request.remote_ip)]) for g in relays],
+			"listeners": [dict(dict(g.request.headers).items() + [("remote_ip", g.request.remote_ip)]) for g in clients],
 			"queues": {n: q.buffered for n, q in queues.iteritems()},
 			"info": get_stats()
 		})


### PR DESCRIPTION
Previously, "debug listeners" were directly-connected clients, and everyone
else had to use a relay. Now, we have a much simpler approach: everyone just
connects directly. This does potentially mean increased load on the main server
(but also means there are no secondary servers required), but it cuts down the
complexity significantly.

All remaining references to 'relays' are now 'clients', because that's what
they are.
