### PR TITLE
Remove automated queueing of tracks and rework the queue for other purposes.

### DIFF
--- a/fore/server.py
+++ b/fore/server.py
@@ -253,7 +253,7 @@ if __name__ == "__main__":
 
 	log.info("Starting %s...", config.app_name)
 
-	track_queue = multiprocessing.Queue(1)
+	track_queue = multiprocessing.Queue()
 	log.info("Initializing read queue to hold %2.2f seconds of audio.",
 			 config.frontend_buffer)
 	v2_queue = BufferedReadQueue(int(config.frontend_buffer / SECONDS_PER_FRAME))
@@ -262,7 +262,6 @@ if __name__ == "__main__":
 	mixer = Mixer(track_queue,v2_queue.raw,info_queue)
 	mixer.start()
 
-	daemonize(database.enqueue_tracks, track_queue)
 	daemonize(info.generate, info_queue, first_frame, InfoHandler)
 	StreamHandler.clients = Listeners(v2_queue, "All", first_frame)
 	daemonize(monitordaemon,StreamHandler.clients,InfoHandler.stats,{"mp3_queue":v2_queue})


### PR DESCRIPTION
The queue is now not actually used, but can have Track objects enqueued onto
it, at which point it will be used as soon as possible; when the queue is
empty, which (in current code) is always the case, a track is chosen by magic.
