### PR TITLE
Switch to using port 80 by default, and (by necessity) add a drop-privs mode.

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -6,7 +6,9 @@ log_config_file_changes: False
 
 lag_limit: 88200        #   samples - how much we can lag by before dropping frames.
 restart_timeout: 3      #   seconds between polls to restart.txt
-http_port: 8192
+http_port: 80
+uid: 1000 # User ID and group ID to drop privileges to
+gid: 1000 # Set both to 0 to not drop privileges, eg if the server is started without privs
 frontend_buffer: 20    #   seconds of audio to buffer in frontend
 past_played_buffer: 600 #   seconds of audio to store track metadata for in the past
 monitor_update_time: 0.5


### PR DESCRIPTION
Connecting to the database has to be deferred until privs have been dropped.
This probably breaks non-**main** usage, but I'm not sure that wasn't already
broken. If/when it's ever needed, check it thoroughly.
