### PR TITLE
Internal-only changes for tidy code; bugfixes track inversion.

### DIFF
--- a/fore/audition.py
+++ b/fore/audition.py
@@ -22,9 +22,9 @@ log = logging.getLogger(__name__)
 LOUDNESS_THRESH = -8
 
 def audition(files, xfade=0, otrim=0, itrim=0, user_name="transition"):
-    filenames = ['audio/' + file[0].encode("UTF-8") for file in files]
+    filenames = ['audio/' + filename.encode("UTF-8") for filename in files]
     two_tracks = make_LAFs(filenames)
-    transition = managed_transition(two_tracks[1], two_tracks[2], xfade=12, otrim=otrim, itrim=itrim)
+    transition = managed_transition(two_tracks[1], two_tracks[2], xfade=xfade, otrim=otrim, itrim=itrim)
     log.warning("What we have here is a list and it looks like %r", transition)
     audition_render(transition, 'transition.mp3')
 

--- a/fore/database.py
+++ b/fore/database.py
@@ -220,11 +220,11 @@ def get_subsequent_track(track_id):
         cur.execute(query)
         return Track(*cur.fetchone())
         
-def get_transition_pair(track1_id, track2_id):
-    """Return filenames for two requested tracks"""
+def get_track_filename(track_id):
+    """Return filename for a specific track, or None"""
     with _conn, _conn.cursor() as cur:
-        cur.execute("SELECT filename FROM tracks WHERE id = "+str(track1_id)+" OR id = "+str(track2_id)+" ORDER BY sequence LIMIT 2")
-        return [file for file in cur.fetchall()]
+        cur.execute("SELECT filename FROM tracks WHERE id = %s", (track_id,))
+        for row in cur: return row[0]
 
 def create_user(username, email, password, hex_key):
 	"""Create a new user, return the newly-created ID"""

--- a/fore/server.py
+++ b/fore/server.py
@@ -343,7 +343,7 @@ class AuditionTransition(BaseHandler):
 		track_otrim=int(self.request.arguments['track_otrim'][0])
 		next_track_itrim=int(self.request.arguments['next_track_itrim'][0])
 		track2_id=int(self.request.arguments['next_track_id'][0])
-		pair_o_tracks = database.get_transition_pair(track1_id, track2_id)
+		pair_o_tracks = database.get_track_filename(track1_id), database.get_track_filename(track2_id)
 		import audition
 		log.warning("We got %r from sending %r and %r", str(pair_o_tracks), track1_id, track2_id)
 		audition.audition(pair_o_tracks,xfade=track_xfade, otrim=track_otrim, itrim=next_track_itrim, user_name=user_name)


### PR DESCRIPTION
Requesting track file names for two tracks out-of-order would result in them
being returned in sequence order, instead of the requested order.