### PR TITLE
Half done - use unique file names for audition temporary files.

### DIFF
--- a/fore/server.py
+++ b/fore/server.py
@@ -541,12 +541,13 @@ class AuditionTransition(BaseHandler):
 		next_track_itrim=int(self.request.arguments['next_track_itrim'][0])
 		track2_id=int(self.request.arguments['next_track_id'][0])
 		pair_o_tracks = database.get_track_filename(track1_id), database.get_track_filename(track2_id)
+		fn = os.urandom(4).encode("hex")+".mp3" # Give us a nice simple eight-character random hex file name
 		import audition
-		threading.Thread(target=audition.audition, args=(pair_o_tracks,track_xfade, track_otrim, next_track_itrim)).start()
+		threading.Thread(target=audition.audition, args=(pair_o_tracks,track_xfade, track_otrim, next_track_itrim, fn)).start()
 		self.write(templates.load("audition.html").generate(
 			track=database.get_single_track(int(track1_id)), compiled=compiled, user_name=user_name,
 			next_track=database.get_single_track(int(track2_id)), track_xfade=track_xfade,
-			track_otrim=track_otrim, next_track_itrim=next_track_itrim))
+			track_otrim=track_otrim, next_track_itrim=next_track_itrim, trackfn=fn))
 
 @route("/rebuild_glitch")
 class RenderGlitch(BaseHandler):

--- a/templates/audition.html
+++ b/templates/audition.html
@@ -24,7 +24,7 @@
 	{{ next_track.track_details['sequence'] }}
 	<table><tr>
 	<td><img src="/artwork/{{ track.id }}.jpg" class="track_art"></td>
-	<td><div class="ui360" style="margin-top:-0.55em"><a id="endpoint_link" href="../transition_audio/transition.mp3" type="audio/mpeg"></a></td>
+	<td><div class="ui360" style="margin-top:-0.55em"><a id="endpoint_link" href="../transition_audio/{{ trackfn }}" type="audio/mpeg"></a></td>
 	<td><img src="/artwork/{{ next_track.id }}.jpg" class="track_art"></td></table>
 	
 	<a href="/manage/{{ track.id }}">Cancel/Reset</a> 	&nbsp; <input type="submit" value="Set Transition Parameters"> 


### PR DESCRIPTION
Requires alterations to admin_main.html to look for the right file, but is
otherwise working. Multiple concurrent auditionings will no longer trample on
each other's files.