### PR TITLE
Remove the .source weakref which doesn't appear to be used.

### DIFF
--- a/fore/mixer.py
+++ b/fore/mixer.py
@@ -41,7 +41,6 @@ from echonest.remix.audio import AudioAnalysis
 
 from pyechonest.util import EchoNestAPIError
 import pyechonest.util
-import weakref
 import numpy
 from echonest.remix.support.ffmpeg import ffmpeg
 
@@ -273,7 +272,6 @@ class LocalAudioStream(AudioStream):
 		# AudioAnalysis) will let any exceptions bubble all the way up,
 		# so we don't have to deal with that here.
 		self.analysis = tempanalysis
-		self.analysis.source = weakref.ref(self)
 
 		class data(object):
 			"""


### PR DESCRIPTION
TODO: Check if everything's working. If stuff starts breaking, revert this,
and then look into the pickling problem (saving an analysis to the db can't
work when there's an unpicklable object in the analysis, so the source link
is breaking that). It may be simplest to just remove the source link, build
the pickle, and then replace the source link; otherwise, actually implement
pickle protocol and specify what attributes are important to us.