### PR TITLE
Redefine the magic selection of tracks.

### DIFF
--- a/glitch/database.py
+++ b/glitch/database.py
@@ -180,7 +180,13 @@ def get_track_to_play(used=[]):
 			log.info("Using enqueued track %s.", track.id)
 		except queue.Empty:
 			# Pick a track that hasn't been played too recently, that hasn't
-			# been played too often, and randomly.
+			# been played too often, and randomly. NOTE: Using a list as the
+			# 'used' collection means PostgreSQL is working with an ARRAY[],
+			# which is searched linearly. Using a Python tuple instead would
+			# mean Postgres works with a ROW[], which *may* outperform this;
+			# however, that would incur efficiency costs in the manipulation
+			# below (pop, append). Question posted on Stack Overflow - check
+			# for more details: http://stackoverflow.com/q/41340837/1236787
 			cur.execute("SELECT "+Track.columns+" FROM tracks WHERE status=1 ORDER BY id=any(%s),played,random() limit 1", [used])
 			row=cur.fetchone()
 			if not row: raise ValueError("Database is empty, cannot enqueue track") from None

--- a/glitch/database.py
+++ b/glitch/database.py
@@ -189,6 +189,7 @@ def get_track_to_play(used=[]):
 			if track.id in used or len(used) > MAX_RECENT_TRACKS:
 				# Periodically wipe out the 'used' collection, resetting
 				# all tracks to the same status.
+				log.debug("Wiping the recent track list.")
 				used[:] = []
 			leak = random.randrange(MAX_RECENT_TRACKS * 2)
 			if leak < len(used):
@@ -197,10 +198,13 @@ def get_track_to_play(used=[]):
 				# being "this track's turn" with complete certainty. The
 				# chances of this occurring are N in MAX, where N is the
 				# number of tracks already listed. Leak that one track.
+				log.debug("Leaking one track from recent track list.")
 				used.pop(leak)
 			# Never play the same track twice running. We _always_ have this
 			# track in the 'used' list for next time.
 			used.append(track.id)
+			log.debug("Added track %s to recent track list (now has %s/%s)",
+				track.id, len(used), MAX_RECENT_TRACKS)
 		# Record that a track has been played.
 		# Currently simply increments the counter; may later keep track of how long since played, etc.
 		cur.execute("UPDATE tracks SET played=played+1 WHERE id=%s", (track.id,))


### PR DESCRIPTION
1) Tracks that not have been played recently are preferred.
2) Once every track has been played recently, the list is cleared.
3) The list is also cleared if we hit fifty tracks (tweakable).
4) Just sometimes, before adding a track to the list, we leak a
   previously-listed track. This happens more often as we approach
   the clear point, but never more than 50% chance.

Hopefully this will be a more "human-friendly" randomness.
